### PR TITLE
fix(ci): add "node" to tsconfig types so tsc resolves Node built-ins

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,
+    "types": ["node"],
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Problem

The CI **build** job fails at the `npx tsc` step on `main`, with errors such as:

- `error TS2591: Cannot find name 'process'`
- `error TS2591: Cannot find name 'node:fs/promises'` / `node:path` / `node:child_process` / `node:crypto`
- `error TS7006: Parameter 'error' implicitly has an 'any' type`

This breaks `main` and consequently blocks the 6 open Dependabot PRs (#74, #75, #77, #78, #79, #80), since their CI runs against the same broken build.

## Root cause

`@types/node` was already present in `devDependencies` and installed correctly. The real problem was a **tsconfig misconfiguration**.

With `module`/`moduleResolution` set to `nodenext`, TypeScript was **not auto-discovering** `@types/node` from `node_modules/@types`. As a result:

- `node:*` import specifiers were treated as unresolvable absolute URIs (`traceResolution` showed: `Skipping module 'node:fs/promises' that looks like an absolute URI`).
- Node global typings (`process`, `Buffer`, etc.) were never loaded.
- Callback parameters typed by Node's `child_process` signatures fell back to implicit `any`.

The TypeScript error message itself recommends the fix: *"add 'node' to the types field in your tsconfig."*

## Fix

Add `"types": ["node"]` to `compilerOptions` in `tsconfig.json`. This is a one-line, minimal change. No dependency or lockfile changes were required.

```diff
   "strict": true,
+  "types": ["node"],
   "esModuleInterop": true,
```

## Verification (local, exact CI commands)

Run with Node 22 (matching the CI workflow):

- `npm ci && npx tsc` → **exit 0**, zero errors (previously ~100+ errors).
- `npm test` → **359 tests pass, 0 fail** (62 suites).

## Impact

Unblocks `main` and the 6 open Dependabot PRs (#74-#80).

🤖 Generated with [Claude Code](https://claude.com/claude-code)