### PR TITLE
fix(site): pin echarts to v5 to fix Deploy Dashboard ERESOLVE

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -14,7 +14,7 @@
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.2.2",
         "astro": "^6.1.3",
-        "echarts": "^6.0.0",
+        "echarts": "^5.6.0",
         "svelte": "^5.55.1",
         "svelte-echarts": "^1.0.0",
         "tailwindcss": "^4.2.2"
@@ -2624,13 +2624,13 @@
       }
     },
     "node_modules/echarts": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.1.0.tgz",
-      "integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
+      "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "6.1.0"
+        "zrender": "5.6.1"
       }
     },
     "node_modules/echarts/node_modules/tslib": {
@@ -5732,9 +5732,9 @@
       }
     },
     "node_modules/zrender": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.1.0.tgz",
-      "integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz",
+      "integrity": "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "tslib": "2.3.0"

--- a/site/package.json
+++ b/site/package.json
@@ -18,7 +18,7 @@
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.2",
     "astro": "^6.1.3",
-    "echarts": "^6.0.0",
+    "echarts": "^5.6.0",
     "svelte": "^5.55.1",
     "svelte-echarts": "^1.0.0",
     "tailwindcss": "^4.2.2"


### PR DESCRIPTION
## Problem

`Deploy Dashboard` is failing on `main`:

```
npm error ERESOLVE could not resolve
npm error While resolving: svelte-echarts@1.0.0
npm error Found: echarts@6.1.0
npm error peer echarts@"^5.0.0" from svelte-echarts@1.0.0
```

`site/package.json` specifies `echarts@^6.0.0`, but `svelte-echarts@1.0.0` (its only published release) requires `peer echarts@^5.0.0`. There is no svelte-echarts release that supports echarts 6.

This slipped through because the `Deploy Dashboard` workflow runs only on push to `main`, never on PRs — so the Dependabot PR that introduced `echarts@^6` showed green.

## Fix

Pin `echarts` to `^5.6.0` and regenerate `package-lock.json`.

## Verification

- `npm ci` — succeeds (307 packages, no ERESOLVE)
- `npx astro build` — completes, 8523 pages built

🤖 Generated with [Claude Code](https://claude.com/claude-code)