### PR TITLE
refactor: dedupe report-store helpers + trend math, drop dead expr (#94, #95)

### DIFF
--- a/site/src/pages/trends.astro
+++ b/site/src/pages/trends.astro
@@ -2,28 +2,10 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import fs from 'node:fs';
 import path from 'node:path';
+import { computeTrendSummary, computeRepoDeltas } from '../../../src/trend-summary.ts';
+import type { TrendSnapshot } from '../../../src/trend.ts';
 
 const base = import.meta.env.BASE_URL;
-
-// Load trend snapshots from data/trends/
-interface TrendRepo {
-  slug: string;
-  score: number;
-  letter: string;
-  dimensions: Record<string, number>;
-  error?: string;
-}
-
-interface TrendSnapshot {
-  meta: {
-    month: string;
-    generated: string;
-    totalRepos: number;
-    successCount: number;
-    failCount: number;
-  };
-  repos: TrendRepo[];
-}
 
 const trendsDir = path.resolve(process.cwd(), '../data/trends');
 let snapshots: TrendSnapshot[] = [];
@@ -70,37 +52,32 @@ let comparison: {
 if (hasComparison) {
   const prev = snapshots[snapshots.length - 2];
   const curr = snapshots[snapshots.length - 1];
-  const prevMap = new Map(prev.repos.filter(r => !r.error).map(r => [r.slug, r]));
 
-  const deltas: RepoDelta[] = [];
-  for (const r of curr.repos.filter(r => !r.error)) {
-    const p = prevMap.get(r.slug);
-    if (p) {
-      deltas.push({
-        slug: r.slug,
-        prevScore: p.score,
-        currScore: r.score,
-        delta: r.score - p.score,
-        prevLetter: p.letter,
-        currLetter: r.letter,
-      });
-    }
-  }
+  // Reuse the canonical trend math (src/trend-summary.ts) so the dashboard and
+  // the `trends` CLI cannot drift. The summary gives the scalars; the per-repo
+  // delta list feeds the table (mapped onto this page's RepoDelta view model).
+  const summary = computeTrendSummary(prev, curr);
+  const { deltas } = computeRepoDeltas(prev, curr);
 
-  const improved = deltas.filter(d => d.delta > 0).length;
-  const regressed = deltas.filter(d => d.delta < 0).length;
-  const unchanged = deltas.filter(d => d.delta === 0).length;
-  const totalDelta = deltas.reduce((s, d) => s + d.delta, 0);
-  const avgDelta = deltas.length > 0 ? Math.round((totalDelta / deltas.length) * 10) / 10 : 0;
+  const repoDeltas: RepoDelta[] = deltas
+    .map(d => ({
+      slug: d.slug,
+      prevScore: d.previousScore,
+      currScore: d.currentScore,
+      delta: d.delta,
+      prevLetter: d.previousLetter,
+      currLetter: d.currentLetter,
+    }))
+    .sort((a, b) => b.delta - a.delta);
 
   comparison = {
-    prevMonth: prev.meta.month,
-    currMonth: curr.meta.month,
-    deltas: deltas.sort((a, b) => b.delta - a.delta),
-    improved,
-    regressed,
-    unchanged,
-    avgDelta,
+    prevMonth: summary.previousMonth,
+    currMonth: summary.currentMonth,
+    deltas: repoDeltas,
+    improved: summary.improved,
+    regressed: summary.regressed,
+    unchanged: summary.unchanged,
+    avgDelta: summary.averageDelta,
   };
 }
 

--- a/src/aggregate.ts
+++ b/src/aggregate.ts
@@ -9,37 +9,24 @@
  * Usage: node dist/aggregate.js
  */
 
-import { readdir, readFile, writeFile, mkdir } from "node:fs/promises";
+import { writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import chalk from "chalk";
-import type { DimensionResult, Finding } from "./dimensions/security.js";
-import type { ProjectType } from "./analyze.js";
+import {
+  findJsonFiles,
+  loadReport,
+  isGraded,
+  type StoredReport,
+  type GradeDistribution,
+} from "./report-store.js";
+
+// Re-exported so existing consumers (and tests) can import isGraded from here.
+export { isGraded };
 
 const DATA_DIR = join(process.cwd(), "data");
 const REPORTS_DIR = join(DATA_DIR, "reports");
 const AGGREGATE_PATH = join(DATA_DIR, "aggregate.json");
 const INDEX_PATH = join(DATA_DIR, "index.json");
-
-interface StoredReport {
-  repo: string;
-  letter: string;
-  overall: number;
-  graded?: boolean;
-  dimensions: DimensionResult[];
-  totalDurationMs: number;
-  projectType: ProjectType;
-  language: string | null;
-  analyzedAt: string;
-  toolVersion: string;
-}
-
-interface GradeDistribution {
-  A: number;
-  B: number;
-  C: number;
-  D: number;
-  F: number;
-}
 
 interface DimensionAverage {
   name: string;
@@ -67,53 +54,6 @@ interface AggregateResult {
   languageBreakdown: Record<string, number>;
   topPassingChecks: CheckStat[];
   topFailingChecks: CheckStat[];
-}
-
-/**
- * Recursively find all JSON files under a directory.
- */
-async function findJsonFiles(dir: string): Promise<string[]> {
-  const files: string[] = [];
-  let entries;
-  try {
-    entries = await readdir(dir, { withFileTypes: true });
-  } catch {
-    return files;
-  }
-  for (const entry of entries) {
-    const fullPath = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      const nested = await findJsonFiles(fullPath);
-      files.push(...nested);
-    } else if (entry.name.endsWith(".json")) {
-      files.push(fullPath);
-    }
-  }
-  return files;
-}
-
-/**
- * Load and parse a report file.
- */
-async function loadReport(filePath: string): Promise<StoredReport | null> {
-  try {
-    const content = await readFile(filePath, "utf-8");
-    return JSON.parse(content) as StoredReport;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Determine whether a stored report represents a graded (code) repo.
- * Older reports without the `graded` field are treated as graded unless
- * their projectType is "documentation".
- */
-export function isGraded(report: StoredReport): boolean {
-  if (report.graded !== undefined) {
-    return report.graded;
-  }
-  return report.projectType !== "documentation";
 }
 
 /**

--- a/src/export.ts
+++ b/src/export.ts
@@ -19,96 +19,23 @@
  * Usage: node dist/export.js
  */
 
-import { readdir, readFile, writeFile, mkdir } from "node:fs/promises";
+import { writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
-import type { Finding, DimensionResult } from "./dimensions/security.js";
 import type { LanguageBreakdownEntry } from "./analyze.js";
-import type { TreeAnalytics } from "./tree-analytics.js";
+import {
+  findJsonFiles,
+  loadReport,
+  isGraded,
+  type StoredReport,
+  type GradeDistribution,
+} from "./report-store.js";
 
 const DATA_DIR = join(process.cwd(), "data");
 const REPORTS_DIR = join(DATA_DIR, "reports");
 const DASHBOARD_DIR = join(DATA_DIR, "dashboard");
 const REPOS_DIR = join(DASHBOARD_DIR, "repos");
 
-interface StoredReport {
-  repo: string;
-  letter: string;
-  overall: number;
-  graded?: boolean;
-  dimensions: Array<DimensionResult & { durationMs?: number }>;
-  totalDurationMs: number;
-  projectType: string;
-  language: string | null;
-  languages?: { primary: string; all: LanguageBreakdownEntry[] };
-  analyzedAt: string;
-  toolVersion: string;
-  // Enriched metadata
-  description?: string;
-  topics?: string[];
-  pushed_at?: string;
-  created_at?: string;
-  forks_count?: number;
-  size?: number;
-  has_discussions?: boolean;
-  // Tree analytics
-  treeAnalytics?: Partial<TreeAnalytics>;
-}
-
-interface GradeDistribution {
-  A: number;
-  B: number;
-  C: number;
-  D: number;
-  F: number;
-}
-
 // ─── Helpers ──────────────────────────────────────────────────────────────────
-
-/**
- * Recursively find all JSON files under a directory.
- */
-async function findJsonFiles(dir: string): Promise<string[]> {
-  const files: string[] = [];
-  let entries;
-  try {
-    entries = await readdir(dir, { withFileTypes: true });
-  } catch {
-    return files;
-  }
-  for (const entry of entries) {
-    const fullPath = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      const nested = await findJsonFiles(fullPath);
-      files.push(...nested);
-    } else if (entry.name.endsWith(".json")) {
-      files.push(fullPath);
-    }
-  }
-  return files;
-}
-
-/**
- * Load and parse a single report file. Returns null on parse failure.
- */
-async function loadReport(filePath: string): Promise<StoredReport | null> {
-  try {
-    const content = await readFile(filePath, "utf-8");
-    return JSON.parse(content) as StoredReport;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Whether a stored report is for a graded (code) repository.
- * Reports without the `graded` field fall back to checking projectType.
- */
-function isGraded(report: StoredReport): boolean {
-  if (report.graded !== undefined) {
-    return report.graded;
-  }
-  return report.projectType !== "documentation";
-}
 
 /**
  * Extract star count from the "Community adoption (stars)" finding detail,
@@ -294,7 +221,10 @@ function buildLeaderboard(reports: StoredReport[]): { repos: LeaderboardEntry[] 
 }
 
 function buildLanguages(reports: StoredReport[]): { languages: LanguageStat[] } {
-  const byLanguage: Record<string, { scores: number[]; gradeDistribution: GradeDistribution; allUngraded: boolean }> = {};
+  const byLanguage: Record<string, { scores: number[]; gradeDistribution: GradeDistribution }> = {};
+
+  // count includes all repos (graded + ungraded) per language.
+  const totalCounts: Record<string, number> = {};
 
   for (const report of reports) {
     const lang = report.language ?? "unknown";
@@ -302,13 +232,12 @@ function buildLanguages(reports: StoredReport[]): { languages: LanguageStat[] } 
       byLanguage[lang] = {
         scores: [],
         gradeDistribution: emptyGradeDistribution(),
-        allUngraded: true,
       };
     }
+    totalCounts[lang] = (totalCounts[lang] ?? 0) + 1;
     const entry = byLanguage[lang];
     if (isGraded(report)) {
       entry.scores.push(report.overall);
-      entry.allUngraded = false;
       const grade = report.letter as keyof GradeDistribution;
       if (grade in entry.gradeDistribution) {
         entry.gradeDistribution[grade]++;
@@ -319,7 +248,7 @@ function buildLanguages(reports: StoredReport[]): { languages: LanguageStat[] } 
   const languages: LanguageStat[] = Object.entries(byLanguage)
     .map(([name, data]) => ({
       name,
-      count: data.scores.length + (data.allUngraded ? 0 : 0),
+      count: totalCounts[name] ?? 0,
       averageScore:
         data.scores.length > 0
           ? Math.round(data.scores.reduce((a, b) => a + b, 0) / data.scores.length)
@@ -327,17 +256,6 @@ function buildLanguages(reports: StoredReport[]): { languages: LanguageStat[] } 
       gradeDistribution: data.gradeDistribution,
     }))
     .sort((a, b) => b.count - a.count);
-
-  // Recompute count to include all repos (graded + ungraded) per language
-  const totalCounts: Record<string, number> = {};
-  for (const report of reports) {
-    const lang = report.language ?? "unknown";
-    totalCounts[lang] = (totalCounts[lang] ?? 0) + 1;
-  }
-  for (const lang of languages) {
-    lang.count = totalCounts[lang.name] ?? 0;
-  }
-  languages.sort((a, b) => b.count - a.count);
 
   return { languages };
 }

--- a/src/report-store.ts
+++ b/src/report-store.ts
@@ -1,0 +1,98 @@
+/**
+ * Shared helpers for reading stored batch reports from data/reports/.
+ *
+ * Both `export.ts` and `aggregate.ts` consume the same on-disk report JSON,
+ * so the file-discovery, parsing and grading helpers live here to keep their
+ * behavior in lockstep (previously they were duplicated byte-for-byte).
+ */
+
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { DimensionResult } from "./dimensions/security.js";
+import type { LanguageBreakdownEntry } from "./analyze.js";
+import type { TreeAnalytics } from "./tree-analytics.js";
+
+/**
+ * A single repo report as persisted under data/reports/.
+ *
+ * This is the permissive superset consumed by both export.ts and aggregate.ts:
+ * `projectType` is a plain string (the analyze `ProjectType` union is a subset)
+ * and the enrichment fields are optional, present only on richer export reports.
+ */
+export interface StoredReport {
+  repo: string;
+  letter: string;
+  overall: number;
+  graded?: boolean;
+  dimensions: Array<DimensionResult & { durationMs?: number }>;
+  totalDurationMs: number;
+  projectType: string;
+  language: string | null;
+  languages?: { primary: string; all: LanguageBreakdownEntry[] };
+  analyzedAt: string;
+  toolVersion: string;
+  // Enriched metadata (export reports only)
+  description?: string;
+  topics?: string[];
+  pushed_at?: string;
+  created_at?: string;
+  forks_count?: number;
+  size?: number;
+  has_discussions?: boolean;
+  // Tree analytics
+  treeAnalytics?: Partial<TreeAnalytics>;
+}
+
+export interface GradeDistribution {
+  A: number;
+  B: number;
+  C: number;
+  D: number;
+  F: number;
+}
+
+/**
+ * Recursively find all JSON files under a directory.
+ */
+export async function findJsonFiles(dir: string): Promise<string[]> {
+  const files: string[] = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return files;
+  }
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const nested = await findJsonFiles(fullPath);
+      files.push(...nested);
+    } else if (entry.name.endsWith(".json")) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+/**
+ * Load and parse a single report file. Returns null on parse failure.
+ */
+export async function loadReport(filePath: string): Promise<StoredReport | null> {
+  try {
+    const content = await readFile(filePath, "utf-8");
+    return JSON.parse(content) as StoredReport;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether a stored report is for a graded (code) repository.
+ * Reports without the `graded` field fall back to checking projectType.
+ */
+export function isGraded(report: StoredReport): boolean {
+  if (report.graded !== undefined) {
+    return report.graded;
+  }
+  return report.projectType !== "documentation";
+}

--- a/src/trend-summary.ts
+++ b/src/trend-summary.ts
@@ -1,0 +1,130 @@
+/**
+ * Pure, side-effect-free trend math shared by the `trends` CLI
+ * (src/trend-view.ts) and the dashboard trends page (site/src/pages/trends.astro).
+ *
+ * Keeping the delta / improved-regressed-unchanged / average-delta computation
+ * in one place stops the CLI output and the dashboard from drifting apart.
+ * This module imports no I/O or rendering deps so it is safe to import at
+ * Astro build time.
+ */
+
+import type { TrendSnapshot, TrendRepoEntry } from "./trend.js";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface TrendDelta {
+  slug: string;
+  previousScore: number;
+  currentScore: number;
+  delta: number;
+  previousLetter: string;
+  currentLetter: string;
+  dimensionDeltas: Record<string, number>;
+}
+
+export interface TrendSummary {
+  previousMonth: string;
+  currentMonth: string;
+  totalRepos: number;
+  improved: number;
+  regressed: number;
+  unchanged: number;
+  averageDelta: number;
+  biggestGainers: TrendDelta[];
+  biggestLosers: TrendDelta[];
+  newRepos: TrendRepoEntry[];
+  droppedRepos: string[];
+}
+
+// ── Analysis ────────────────────────────────────────────────────────────────
+
+/**
+ * Compute per-repo score deltas between two snapshots, along with the repos
+ * that are new (only in `current`) or dropped (only in `previous`). Repos with
+ * an `error` in either snapshot are ignored.
+ */
+export function computeRepoDeltas(
+  previous: TrendSnapshot,
+  current: TrendSnapshot,
+): { deltas: TrendDelta[]; newRepos: TrendRepoEntry[]; droppedRepos: string[] } {
+  const prevMap = new Map(
+    previous.repos
+      .filter((r) => !r.error)
+      .map((r) => [r.slug, r])
+  );
+  const currMap = new Map(
+    current.repos
+      .filter((r) => !r.error)
+      .map((r) => [r.slug, r])
+  );
+
+  const deltas: TrendDelta[] = [];
+  const newRepos: TrendRepoEntry[] = [];
+  const droppedRepos: string[] = [];
+
+  // Compute deltas for repos in both snapshots
+  for (const [slug, curr] of currMap) {
+    const prev = prevMap.get(slug);
+    if (!prev) {
+      newRepos.push(curr);
+      continue;
+    }
+
+    const dimensionDeltas: Record<string, number> = {};
+    for (const [dimName, dimScore] of Object.entries(curr.dimensions)) {
+      const prevDimScore = prev.dimensions[dimName] ?? 0;
+      dimensionDeltas[dimName] = dimScore - prevDimScore;
+    }
+
+    deltas.push({
+      slug,
+      previousScore: prev.score,
+      currentScore: curr.score,
+      delta: curr.score - prev.score,
+      previousLetter: prev.letter,
+      currentLetter: curr.letter,
+      dimensionDeltas,
+    });
+  }
+
+  // Find dropped repos (in previous but not current)
+  for (const slug of prevMap.keys()) {
+    if (!currMap.has(slug)) {
+      droppedRepos.push(slug);
+    }
+  }
+
+  return { deltas, newRepos, droppedRepos };
+}
+
+export function computeTrendSummary(
+  previous: TrendSnapshot,
+  current: TrendSnapshot,
+): TrendSummary {
+  const { deltas, newRepos, droppedRepos } = computeRepoDeltas(previous, current);
+
+  const improved = deltas.filter((d) => d.delta > 0).length;
+  const regressed = deltas.filter((d) => d.delta < 0).length;
+  const unchanged = deltas.filter((d) => d.delta === 0).length;
+  const totalDelta = deltas.reduce((sum, d) => sum + d.delta, 0);
+  const averageDelta = deltas.length > 0 ? Math.round((totalDelta / deltas.length) * 10) / 10 : 0;
+
+  // Sort by delta descending for gainers, ascending for losers
+  const sorted = [...deltas].sort((a, b) => b.delta - a.delta);
+  const biggestGainers = sorted.filter((d) => d.delta > 0).slice(0, 5);
+  const biggestLosers = sorted.filter((d) => d.delta < 0).reverse().slice(0, 5);
+
+  return {
+    previousMonth: previous.meta.month,
+    currentMonth: current.meta.month,
+    totalRepos: deltas.length,
+    improved,
+    regressed,
+    unchanged,
+    averageDelta,
+    biggestGainers,
+    biggestLosers,
+    newRepos,
+    droppedRepos,
+  };
+}

--- a/src/trend-view.ts
+++ b/src/trend-view.ts
@@ -17,112 +17,19 @@
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import chalk from "chalk";
-import type { TrendSnapshot, TrendRepoEntry } from "./trend.js";
+import type { TrendSnapshot } from "./trend.js";
 
-// ── Types ──────────────────────────────────────────────────────────────────
+// The trend math lives in a pure, side-effect-free module so the dashboard
+// (site/src/pages/trends.astro) can reuse it at build time. Re-exported here
+// for backward compatibility with existing importers/tests.
+export {
+  computeTrendSummary,
+  computeRepoDeltas,
+  type TrendDelta,
+  type TrendSummary,
+} from "./trend-summary.js";
 
-export interface TrendDelta {
-  slug: string;
-  previousScore: number;
-  currentScore: number;
-  delta: number;
-  previousLetter: string;
-  currentLetter: string;
-  dimensionDeltas: Record<string, number>;
-}
-
-export interface TrendSummary {
-  previousMonth: string;
-  currentMonth: string;
-  totalRepos: number;
-  improved: number;
-  regressed: number;
-  unchanged: number;
-  averageDelta: number;
-  biggestGainers: TrendDelta[];
-  biggestLosers: TrendDelta[];
-  newRepos: TrendRepoEntry[];
-  droppedRepos: string[];
-}
-
-// ── Analysis ────────────────────────────────────────────────────────────────
-
-export function computeTrendSummary(
-  previous: TrendSnapshot,
-  current: TrendSnapshot,
-): TrendSummary {
-  const prevMap = new Map(
-    previous.repos
-      .filter((r) => !r.error)
-      .map((r) => [r.slug, r])
-  );
-  const currMap = new Map(
-    current.repos
-      .filter((r) => !r.error)
-      .map((r) => [r.slug, r])
-  );
-
-  const deltas: TrendDelta[] = [];
-  const newRepos: TrendRepoEntry[] = [];
-  const droppedRepos: string[] = [];
-
-  // Compute deltas for repos in both snapshots
-  for (const [slug, curr] of currMap) {
-    const prev = prevMap.get(slug);
-    if (!prev) {
-      newRepos.push(curr);
-      continue;
-    }
-
-    const dimensionDeltas: Record<string, number> = {};
-    for (const [dimName, dimScore] of Object.entries(curr.dimensions)) {
-      const prevDimScore = prev.dimensions[dimName] ?? 0;
-      dimensionDeltas[dimName] = dimScore - prevDimScore;
-    }
-
-    deltas.push({
-      slug,
-      previousScore: prev.score,
-      currentScore: curr.score,
-      delta: curr.score - prev.score,
-      previousLetter: prev.letter,
-      currentLetter: curr.letter,
-      dimensionDeltas,
-    });
-  }
-
-  // Find dropped repos (in previous but not current)
-  for (const slug of prevMap.keys()) {
-    if (!currMap.has(slug)) {
-      droppedRepos.push(slug);
-    }
-  }
-
-  const improved = deltas.filter((d) => d.delta > 0).length;
-  const regressed = deltas.filter((d) => d.delta < 0).length;
-  const unchanged = deltas.filter((d) => d.delta === 0).length;
-  const totalDelta = deltas.reduce((sum, d) => sum + d.delta, 0);
-  const averageDelta = deltas.length > 0 ? Math.round((totalDelta / deltas.length) * 10) / 10 : 0;
-
-  // Sort by delta descending for gainers, ascending for losers
-  const sorted = [...deltas].sort((a, b) => b.delta - a.delta);
-  const biggestGainers = sorted.filter((d) => d.delta > 0).slice(0, 5);
-  const biggestLosers = sorted.filter((d) => d.delta < 0).reverse().slice(0, 5);
-
-  return {
-    previousMonth: previous.meta.month,
-    currentMonth: current.meta.month,
-    totalRepos: deltas.length,
-    improved,
-    regressed,
-    unchanged,
-    averageDelta,
-    biggestGainers,
-    biggestLosers,
-    newRepos,
-    droppedRepos,
-  };
-}
+import { computeTrendSummary, type TrendSummary } from "./trend-summary.js";
 
 // ── Loading ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
Two cleanup issues in the dashboard/aggregate/trend code.

### #95 — duplicated helpers + dead expression
- `findJsonFiles` / `loadReport` / `isGraded` (and the `StoredReport` / `GradeDistribution` types) were byte-identical in `export.ts` and `aggregate.ts`. Extracted to a new `src/report-store.ts` with a permissive superset `StoredReport`; both files now import it. `aggregate.ts` re-exports `isGraded` so existing importers and `tests/aggregate.test.js` (which imports it from `dist/aggregate.js`) keep working unchanged.
- Removed the dead `(data.allUngraded ? 0 : 0)` no-op in `buildLanguages` and the vestigial `allUngraded` accumulator field; language `count` is now computed once from `totalCounts` (the value it was always overwritten with anyway).

### #94 — trends.astro reimplemented computeTrendSummary
- `trends.astro` duplicated the prev-vs-current delta math. Factored the pure trend math into a **side-effect-free** `src/trend-summary.ts` (`computeRepoDeltas` + `computeTrendSummary`); `trend-view.ts` re-exports it (preserving the `dist/trend-view.js` import surface used by `tests/trend.test.js`). The Astro frontmatter now imports the pure module at build time and maps `TrendDelta` onto its existing `RepoDelta` view model.
- **Rendered output verified byte-identical**: built `/trends/index.html` before and after with synthetic 2-snapshot data; the only diff was the build-nondeterministic hashed CSS filename.

## CI
- `npx tsc`: clean
- `npm test`: 372 passed / 0 failed
- `cd site && npx astro build`: succeeds (8524 pages, `/trends` included)

## Note for reviewers
#94 touches a rendered dashboard page and adds a build-time cross-package TS import (`site` → `../../../src/trend-summary.ts`). Output was verified unchanged, but flagging since it crosses the site/lib boundary — holding off on auto-merge for a human look.

Fixes #94
Fixes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)