### PR TITLE
fix(security): resolve ReDoS + incomplete-URL-sanitization CodeQL alerts

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -403,17 +403,41 @@ export function treeHasFile(tree: RepoTree, path: string): boolean {
 }
 
 /**
+ * Maximum file-path length we will run a detector regex against.
+ *
+ * Git itself limits a tree path to 4096 bytes, so any legitimate entry is
+ * comfortably under this bound. Several detector patterns have the shape
+ * `prefix.*X.*suffix$` (two unanchored `.*` runs), which can exhibit
+ * polynomial backtracking when the suffix fails to match on a long,
+ * adversarially-constructed path supplied by an analyzed (untrusted) repo.
+ * Bounding the input length keeps that O(n^2) worst case to a constant and
+ * closes the `js/polynomial-redos` class without altering match semantics for
+ * any real path. See https://codeql.github.com/codeql-query-help/javascript/js-polynomial-redos/
+ */
+const MAX_TREE_PATH_LENGTH = 4096;
+
+/**
+ * Test a single tree path against a detector pattern, skipping pathologically
+ * long inputs that could drive regex backtracking. Real git paths are always
+ * well under {@link MAX_TREE_PATH_LENGTH}.
+ */
+function pathMatches(path: string, pattern: RegExp): boolean {
+  if (path.length > MAX_TREE_PATH_LENGTH) return false;
+  return pattern.test(path);
+}
+
+/**
  * Check if any file in the tree matches a pattern.
  */
 export function treeHasPattern(tree: RepoTree, pattern: RegExp): boolean {
-  return tree.tree.some((entry) => pattern.test(entry.path));
+  return tree.tree.some((entry) => pathMatches(entry.path, pattern));
 }
 
 /**
  * Count files matching a pattern.
  */
 export function treeCountPattern(tree: RepoTree, pattern: RegExp): number {
-  return tree.tree.filter((entry) => pattern.test(entry.path)).length;
+  return tree.tree.filter((entry) => pathMatches(entry.path, pattern)).length;
 }
 
 export type ProjectType = "application" | "iac" | "library" | "hybrid" | "documentation" | "runtime" | "mirror";

--- a/src/platforms.ts
+++ b/src/platforms.ts
@@ -47,6 +47,47 @@ function parseGitHubSlug(input: string): string {
 }
 
 /**
+ * Return the URL hostname for a string that looks like a URL, or `null` when
+ * the input is not a parseable absolute http(s) URL (e.g. a plain "owner/repo"
+ * slug, or a malformed/non-http URL).
+ *
+ * This is the basis for an exact-host check. A naive `input.includes("gitlab.com")`
+ * is bypassable by hosts such as `gitlab.com.attacker.com` or
+ * `evil-gitlab.com`, and by credential tricks like
+ * `https://gitlab.com@attacker.com/...` (whose host is `attacker.com`).
+ */
+function urlHostname(input: string): string | null {
+  // Accept scheme-relative / bare-host forms like "gitlab.com/owner/repo" by
+  // defaulting to https, but only when the first path segment looks like a
+  // hostname (contains a dot). A plain "owner/repo" slug must NOT be coerced
+  // into a host, so it returns null and falls through to the GitHub default.
+  const candidate =
+    /^https?:\/\//i.test(input) || !/^[^/]+\.[^/]+\//.test(input)
+      ? input
+      : `https://${input}`;
+
+  let url: URL;
+  try {
+    url = new URL(candidate);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return null;
+  }
+  return url.hostname.toLowerCase();
+}
+
+/**
+ * Exact host match, allowing only the host itself or a real subdomain of it.
+ * Rejects look-alikes (`evil-github.com`), suffix tricks
+ * (`github.com.evil.com`), and substring matches.
+ */
+function hostMatches(hostname: string, host: string): boolean {
+  return hostname === host || hostname.endsWith(`.${host}`);
+}
+
+/**
  * Detect the hosting platform from user input (URL or slug).
  *
  * Supported:
@@ -56,8 +97,13 @@ function parseGitHubSlug(input: string): string {
  * - owner/repo (plain)     → GitHub (default)
  */
 export function detectPlatform(input: string): PlatformConfig {
+  // Resolve the real hostname for URL inputs so that host checks compare the
+  // actual host, never a substring of the raw string. Plain "owner/repo"
+  // slugs parse to `null` and fall through to the GitHub default below.
+  const hostname = urlHostname(input);
+
   // GitLab
-  if (input.includes("gitlab.com")) {
+  if (hostname !== null && hostMatches(hostname, "gitlab.com")) {
     const match = input.match(
       /gitlab\.com\/([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)/
     );
@@ -75,7 +121,7 @@ export function detectPlatform(input: string): PlatformConfig {
   }
 
   // Codeberg
-  if (input.includes("codeberg.org")) {
+  if (hostname !== null && hostMatches(hostname, "codeberg.org")) {
     const match = input.match(
       /codeberg\.org\/([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)/
     );

--- a/tests/platforms.test.js
+++ b/tests/platforms.test.js
@@ -99,4 +99,56 @@ describe("detectPlatform", () => {
     assert.equal(result.platform, "github");
     assert.equal(result.slug, "owner/repo.js");
   });
+
+  it("detects bare-host gitlab.com (no scheme)", () => {
+    const result = detectPlatform("gitlab.com/owner/repo");
+    assert.equal(result.platform, "gitlab");
+    assert.equal(result.slug, "owner/repo");
+  });
+
+  // ── Host-spoofing rejection (js/incomplete-url-substring-sanitization) ──
+
+  it("does NOT treat suffix-spoof 'gitlab.com.evil.com' as GitLab", () => {
+    // Real host is evil.com; must not be classified as GitLab. It falls to the
+    // GitHub default, where the spoofed-host URL is rejected outright.
+    assert.throws(
+      () => detectPlatform("https://gitlab.com.evil.com/owner/repo"),
+      /Invalid repo format/
+    );
+  });
+
+  it("does NOT treat look-alike 'evil-gitlab.com' as GitLab", () => {
+    assert.throws(
+      () => detectPlatform("https://evil-gitlab.com/owner/repo"),
+      /Invalid repo format/
+    );
+  });
+
+  it("does NOT treat suffix-spoof 'codeberg.org.evil.com' as Codeberg", () => {
+    assert.throws(
+      () => detectPlatform("https://codeberg.org.evil.com/owner/repo"),
+      /Invalid repo format/
+    );
+  });
+
+  it("rejects credential-host spoof 'https://github.com@evil.com'", () => {
+    // URL host is evil.com, not github.com — parseGitHubSlug must reject it.
+    assert.throws(
+      () => detectPlatform("https://github.com@evil.com/owner/repo"),
+      /Invalid repo format/
+    );
+  });
+
+  it("rejects credential-host spoof 'https://gitlab.com@evil.com'", () => {
+    assert.throws(
+      () => detectPlatform("https://gitlab.com@evil.com/owner/repo"),
+      /Invalid repo format/
+    );
+  });
+
+  it("still accepts a real gitlab.com subdomain host", () => {
+    // Self-managed GitLab on a subdomain should still resolve to GitLab.
+    const result = detectPlatform("https://repo.gitlab.com/owner/repo");
+    assert.equal(result.platform, "gitlab");
+  });
 });

--- a/tests/tree-pattern-redos.test.js
+++ b/tests/tree-pattern-redos.test.js
@@ -1,0 +1,81 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { treeHasPattern, treeCountPattern } from "../dist/analyze.js";
+
+/** Helper: build a RepoTree from a list of path strings (all blobs). */
+function mockTree(paths) {
+  return { tree: paths.map((p) => ({ path: p, type: "blob" })) };
+}
+
+describe("treeHasPattern / treeCountPattern", () => {
+  // ── Behavior preservation ─────────────────────────────────────────────
+
+  it("matches legitimate CodeQL workflow paths", () => {
+    const tree = mockTree([
+      "README.md",
+      ".github/workflows/codeql.yml",
+    ]);
+    assert.equal(
+      treeHasPattern(tree, /\.github\/workflows\/.*codeql.*\.ya?ml$/),
+      true
+    );
+  });
+
+  it("matches with the .yaml (long) extension too", () => {
+    const tree = mockTree([".github/workflows/codeql-analysis.yaml"]);
+    assert.equal(treeHasPattern(tree, /codeql.*\.ya?ml$/), true);
+  });
+
+  it("does not match unrelated paths", () => {
+    const tree = mockTree(["src/index.ts", "docs/guide.md"]);
+    assert.equal(treeHasPattern(tree, /codeql.*\.ya?ml$/), false);
+  });
+
+  it("counts only matching entries", () => {
+    const tree = mockTree([
+      ".github/workflows/codeql.yml",
+      ".github/workflows/ci.yml",
+      ".github/workflows/codeql-extended.yaml",
+    ]);
+    assert.equal(
+      treeCountPattern(tree, /codeql.*\.ya?ml$/),
+      2
+    );
+  });
+
+  // ── ReDoS hardening (js/polynomial-redos) ─────────────────────────────
+
+  it("returns quickly on an adversarial long path that forces backtracking", () => {
+    // Pattern of the shape prefix.*X.*suffix$ — the classic polynomial
+    // backtracking case when the trailing suffix never matches.
+    const pattern = /\.github\/workflows\/.*codeql.*\.ya?ml$/;
+    // Long path that starts like the prefix but can never satisfy the `$`
+    // suffix, which is what drives the worst-case backtracking.
+    const evil =
+      ".github/workflows/codeql" + "a".repeat(200_000) + "!";
+    const tree = mockTree([evil]);
+
+    const start = process.hrtime.bigint();
+    const result = treeHasPattern(tree, pattern);
+    const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6;
+
+    assert.equal(result, false);
+    // Without the length bound this regex can take seconds-to-minutes on
+    // such input; bounded, it must complete near-instantly.
+    assert.ok(
+      elapsedMs < 250,
+      `expected bounded match time, took ${elapsedMs.toFixed(1)}ms`
+    );
+  });
+
+  it("over-long paths never match (skipped before regex runs)", () => {
+    const longButValid =
+      ".github/workflows/codeql" + "a".repeat(10_000) + ".yml";
+    const tree = mockTree([longButValid]);
+    // Path exceeds the 4096-byte git path bound, so it is skipped.
+    assert.equal(
+      treeHasPattern(tree, /\.github\/workflows\/.*codeql.*\.ya?ml$/),
+      false
+    );
+  });
+});


### PR DESCRIPTION
Resolves two HIGH CodeQL alerts.

## 1. js/polynomial-redos — `src/analyze.ts`

**Vuln:** `treeHasPattern`/`treeCountPattern` run caller-supplied detector regexes via `pattern.test(entry.path)` against file paths from an *analyzed* (untrusted) repo's git tree. Many detector patterns have the shape `prefix.*X.*suffix$` (two unanchored `.*` runs), e.g. `/\.github\/workflows\/.*codeql.*\.ya?ml$/`, `/code-scanning.*\.ya?ml$/`, `/^\.github\/workflows\/.*release.*\.ya?ml$/i`, `/pmd.*\.xml$/`. When the trailing suffix fails to match on a long adversarial path, these exhibit polynomial (O(n²)) backtracking.

**Fix:** Route both sinks through a `pathMatches()` helper that skips any path longer than `MAX_TREE_PATH_LENGTH` (4096, git's own path-byte limit) before calling `.test()`. The O(n²) worst case becomes constant; every legitimate path (always well under 4096) matches exactly as before. Remediation per CodeQL's documented "limit the length of the input" guidance.

**Test (`tests/tree-pattern-redos.test.js`):** legitimate `codeql.yml`/`.yaml` paths still match; bounded-time assertion (<250ms) on an adversarial `…codeql` + 200k chars + `!` path that previously forced backtracking; over-4096 paths are skipped.

## 2. js/incomplete-url-substring-sanitization — `src/platforms.ts:60,78`

**Vuln:** Platform detection used `input.includes("gitlab.com")` / `input.includes("codeberg.org")` on the raw input. Bypassable by:
- `https://gitlab.com.evil.com/owner/repo` (suffix spoof)
- `https://evil-gitlab.com/owner/repo` (look-alike)
- `https://gitlab.com@evil.com/owner/repo` (credential trick; real host is `evil.com`)

**Fix:** Added `urlHostname()` (parses via `new URL`, also coerces bare-host forms like `gitlab.com/owner/repo`, rejects non-http(s)) and `hostMatches(hostname, host)` (exact host or true `.host` subdomain). Detection now compares the real `.hostname`. Spoofed hosts fail both forge checks, fall to the GitHub default, and are rejected by `parseGitHubSlug`.

**Test (`tests/platforms.test.js`):** the three spoof inputs above (plus `codeberg.org.evil.com`, `github.com@evil.com`) are REJECTED (`throws /Invalid repo format/`); legitimate `https://gitlab.com/...`, bare `gitlab.com/owner/repo`, and a real `repo.gitlab.com` subdomain are accepted.

## Verification
- `npx tsc` clean
- `npm test` — 385 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)